### PR TITLE
Replace cl-bodge.math with cl-bodge.engine package

### DIFF
--- a/01. Vectors/Example 1.5: Vector magnitude/sketch.lisp
+++ b/01. Vectors/Example 1.5: Vector magnitude/sketch.lisp
@@ -1,7 +1,7 @@
 (defpackage :nature-of-code.vectors.example-5
   (:export :start-sketch)
   (:use :cl :trivial-gamekit)
-  (:import-from :cl-bodge.math :vector-length))
+  (:import-from :cl-bodge.engine :vector-length))
 (in-package :nature-of-code.vectors.example-5)
 
 (defvar *width* 800)

--- a/01. Vectors/Example 1.6: Normalizing a vector/sketch.lisp
+++ b/01. Vectors/Example 1.6: Normalizing a vector/sketch.lisp
@@ -1,7 +1,7 @@
 (defpackage :nature-of-code.vectors.example-6
   (:export :start-sketch)
   (:use :cl :trivial-gamekit)
-  (:import-from :cl-bodge.math :vector-length :normalize))
+  (:import-from :cl-bodge.engine :vector-length :normalize))
 (in-package :nature-of-code.vectors.example-6)
 
 (defvar *width* 800)


### PR DESCRIPTION
`cl-bodge.math` package was recently removed from `cl-bodge`, but both old `cl-bodge.engine` (in stable dist) and updated `cl-bodge.engine` packages (testing dist) should have required symbols exported. My apologies, I had no idea it was used at the time of a removal.

While we are at it, can I add your project to the list on https://borodust.org/projects/trivial-gamekit/#projects page?

Btw, awesome project!